### PR TITLE
replace request id middleware using a custom version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var express = require('express'),
-    requestIdMiddleware = require('request-id/express')(),
+    requestIdMiddleware = require('./request_id')(),
     _ = require('lodash'),
     routes = require('./lib/routes'),
     metadataLoader = require('./lib/metadata'),

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash": "^4.5.0",
     "lodash-inflection": "^1.3.2",
     "logger-facade-nodejs": "1.0.0",
-    "request-id": "^0.10.0",
+    "node-uuid": "^1.4.7",
     "zmq-service-suite-client": "0.1.0"
   },
   "devDependencies": {

--- a/request_id.js
+++ b/request_id.js
@@ -1,0 +1,26 @@
+var uuid = require('node-uuid').v4;
+
+function defaults(options) {
+  options = options || {};
+
+  return {
+    reqHeader: options.reqHeader || 'X-Request-Id',
+    resHeader: options.resHeader || 'X-Request-Id',
+    paramName: options.paramName || 'requestId',
+    generator: options.generator || uuid
+  };
+}
+
+module.exports = function requestId(options) {
+  var opts = defaults(options);
+
+  return function (req, res, next) {
+    if(!req[opts.paramName]){
+      req[opts.paramName] = req.get(opts.reqHeader) ||
+        req.query[opts.paramName] || opts.generator();
+      res.setHeader(opts.resHeader, req[opts.paramName]);
+    }
+
+    next();
+  };
+};


### PR DESCRIPTION
there are a PR open to support checking if the id was generated, until
there we need to use a customer version