### PR TITLE
use dot notation for logger names and micro namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,16 +207,16 @@ As an example we can have the following model configuration (metadata from api-e
 
 This will generate the following routes:
 
-    API::METADATA::INFO - Loaded API Models...
-    API::METADATA::INFO - Loading API routes...
-    API::METADATA::INFO - Mount route GET     /v1/users/:userId/roles
-    API::METADATA::INFO - Mount route GET     /v1/users/:userId/roles/:id
-    API::METADATA::INFO - Mount route POST    /v1/users/:userId/roles
-    API::METADATA::INFO - Mount route PUT     /v1/users/:userId/roles/:id
-    API::METADATA::INFO - Mount route DELETE  /v1/users/:userId/roles/:id
+    MICRO.API.METADATA::INFO - Loaded API Models...
+    MICRO.API.METADATA::INFO - Loading API routes...
+    MICRO.API.METADATA::INFO - Mount route GET     /v1/users/:userId/roles
+    MICRO.API.METADATA::INFO - Mount route GET     /v1/users/:userId/roles/:id
+    MICRO.API.METADATA::INFO - Mount route POST    /v1/users/:userId/roles
+    MICRO.API.METADATA::INFO - Mount route PUT     /v1/users/:userId/roles/:id
+    MICRO.API.METADATA::INFO - Mount route DELETE  /v1/users/:userId/roles/:id
     ...
-    API::METADATA::INFO - Loaded API routes...
-    API::INFO - Server running on port 8081
+    MICRO.API.METADATA::INFO - Loaded API routes...
+    MICRO.API::INFO - Server running on port 8081
 
 The parameters `userId` and `id`(on resource endpoints only) will be sent to service on payload.
 
@@ -239,9 +239,9 @@ As an example we can have the following model configuration (metadata from api-e
 
 This will generate the following routes:
 
-    API::METADATA::INFO - Loaded API Models...
-    API::METADATA::INFO - Loading API routes...
-    API::METADATA::INFO - Mount route GET 	/v1/admin/claims
+    MICRO.API.METADATA::INFO - Loaded API Models...
+    MICRO.API.METADATA::INFO - Loading API routes...
+    MICRO.API.METADATA::INFO - Mount route GET 	/v1/admin/claims
 
 ## Overriding default paths
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var express = require('express'),
     metadataLoader = require('./lib/metadata'),
     partialResponseMiddleware = require('express-partial-response'),
     Logger = require('./logger'),
-    log = Logger.getLogger('API::METADATA');
+    log = Logger.getLogger('micro.api.metadata');
 
 function loadingRoutes(router, modelData, config){
   routes(config, modelData).map(function(route){

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 var ZSSClient = require('zmq-service-suite-client'),
     _ = require('lodash'),
     Logger = require('../logger'),
-    log = Logger.getLogger('API::MicroClient'),
+    log = Logger.getLogger('micro.api.client'),
     util = require('util');
 
 

--- a/lib/handlers/collection.js
+++ b/lib/handlers/collection.js
@@ -1,5 +1,5 @@
 var Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler::Collection'),
+    log = Logger.getLogger('micro.api.handler.collection'),
     handleErrors = require('./error'),
     factory = require('./factory');
 

--- a/lib/handlers/create.js
+++ b/lib/handlers/create.js
@@ -1,5 +1,5 @@
 var Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler::Create'),
+    log = Logger.getLogger('micro.api.handler.create'),
     handleErrors = require('./error'),
     factory = require('./factory'),
     _ = require('lodash');

--- a/lib/handlers/error.js
+++ b/lib/handlers/error.js
@@ -1,6 +1,6 @@
 var Logger = require('../../logger'),
     errorHelper = require('../error_helper'),
-    log = Logger.getLogger('API::Handler');
+    log = Logger.getLogger('micro.api.handler');
 
 function handleErrors(runtimeConfig, res, next) {
   return function (err) {

--- a/lib/handlers/factory.js
+++ b/lib/handlers/factory.js
@@ -1,6 +1,6 @@
 var model = require('../model'),
     Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler'),
+    log = Logger.getLogger('micro.api.handler'),
     clientFactory = require('../client'),
     _ = require('lodash'),
     enforceNumber = require('./enforce_number'),

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -1,5 +1,5 @@
 var Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler::Get'),
+    log = Logger.getLogger('micro.api.handler.get'),
     handleErrors = require('./error'),
     factory = require('./factory');
 

--- a/lib/handlers/non_standard_action.js
+++ b/lib/handlers/non_standard_action.js
@@ -1,5 +1,5 @@
 var Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler::NonStandardAction'),
+    log = Logger.getLogger('micro.api.handler.nonstandardaction'),
     handleErrors = require('./error'),
     factory = require('./factory'),
     _ = require('lodash');

--- a/lib/handlers/remove.js
+++ b/lib/handlers/remove.js
@@ -1,5 +1,5 @@
 var Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler::Remove'),
+    log = Logger.getLogger('micro.api.handler.remove'),
     handleErrors = require('./error'),
     factory = require('./factory');
 

--- a/lib/handlers/resource_relation.js
+++ b/lib/handlers/resource_relation.js
@@ -1,5 +1,5 @@
 var Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler::ResourceRelation'),
+    log = Logger.getLogger('micro.api.handler.resourcerelation'),
     handleErrors = require('./error'),
     factory = require('./factory');
 

--- a/lib/handlers/resource_relation_count.js
+++ b/lib/handlers/resource_relation_count.js
@@ -1,5 +1,5 @@
 var Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler::ResourceRelationCount'),
+    log = Logger.getLogger('micro.api.handler.resourcerelationcount'),
     handleErrors = require('./error'),
     factory = require('./factory');
 

--- a/lib/handlers/update.js
+++ b/lib/handlers/update.js
@@ -1,5 +1,5 @@
 var Logger = require('../../logger'),
-    log = Logger.getLogger('API::Handler::Update'),
+    log = Logger.getLogger('micro.api.handler.update'),
     handleErrors = require('./error'),
     factory = require('./factory'),
     _ = require('lodash');

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -2,7 +2,7 @@ var util = require('util'),
     _ = require('lodash'),
     inflection = require('lodash-inflection'),
     Logger = require('../logger'),
-    log = Logger.getLogger('API::Metadata::Loader');
+    log = Logger.getLogger('micro.api.metadata.loader');
 
 _.mixin(inflection);
 


### PR DESCRIPTION
fix #90 