### PR TITLE
Revert "Revert "update project dependencies""

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,25 +10,25 @@
   "author": "Pedro Januário <prnjanuario@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.14.2",
-    "express": "^4.13.3",
+    "body-parser": "^1.15.2",
+    "express": "^4.14.0",
     "express-partial-response": "^0.3.4",
-    "lodash": "^4.5.0",
-    "lodash-inflection": "^1.3.2",
+    "lodash": "^4.14.0",
+    "lodash-inflection": "^1.4.0",
     "logger-facade-nodejs": "1.0.0",
     "request-id": "^0.11.0",
-    "zmq-service-suite-client": "0.1.0"
+    "zmq-service-suite-client": "0.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "grunt": "^0.4.5",
-    "grunt-bump": "^0.7.0",
-    "istanbul": "^0.4.2",
-    "jshint": "^2.9.1",
-    "mocha": "^2.4.5",
+    "grunt": "^1.0.1",
+    "grunt-bump": "^0.8.0",
+    "istanbul": "^0.4.4",
+    "jshint": "^2.9.2",
+    "mocha": "^2.5.3",
     "q": "^1.4.1",
-    "sinon": "^1.17.2",
-    "sinon-as-promised": "^4.0.0",
+    "sinon": "^1.17.5",
+    "sinon-as-promised": "^4.0.2",
     "sinon-chai": "^2.8.0",
     "supertest": "^1.2.0"
   }


### PR DESCRIPTION
Reverts micro-toolkit/api-generator-js#94

We can update the dependencies back to last version since the problem was related with other things. https://github.com/micro-toolkit/api-generator-js/pull/98