### PR TITLE
id gets removed on resourcerelation calls

### DIFF
--- a/lib/handlers/resource_relation.js
+++ b/lib/handlers/resource_relation.js
@@ -1,7 +1,8 @@
 var Logger = require('../../logger'),
     log = Logger.getLogger('micro.api.handler.resourcerelation'),
     handleErrors = require('./error'),
-    factory = require('./factory');
+    factory = require('./factory'),
+    _ = require('lodash');
 
 function resourceRelationHandler(relation, config) {
   var metadataIndex = config.metadata[relation.version];
@@ -17,6 +18,8 @@ function resourceRelationHandler(relation, config) {
     }
 
     req.micro.payload[relation.modelFk] = req.params.id;
+    req.micro.payload = _.omit(req.micro.payload, ['id']);
+
     req.micro.client.list(req.micro.payload, req.micro.headers)
       .then(function(data){
         log.trace('resource relation data received: %j', data.payload);

--- a/tests/handlers_test.js
+++ b/tests/handlers_test.js
@@ -930,6 +930,14 @@ describe('Handlers Generators', function(){
       actionStub.should.have.been.calledWith(sinon.match({ userId: '1' }));
     });
 
+    it('should not call micro client with id key', function(){
+      var actionStub = sinon.stub(clientStub, 'list')
+        .resolves({payload: []});
+      req.params.id = '1';
+      target.resourceRelation(metadata.v1.user.relations[0])(req, res, next);
+      actionStub.should.not.have.been.calledWith(sinon.match({ id: '1' }));
+    });
+
     describe('when parent metadata with current user', function () {
       it('should call micro client with current user key', function(){
         var actionStub = sinon.stub(clientStub, 'list')

--- a/tests/integration/tasks_test.js
+++ b/tests/integration/tasks_test.js
@@ -111,16 +111,23 @@ describe('Integration: Tasks Endpoints', function(){
     });
   });
 
-  describe('GET /v1/users/1/tasks', function(){
+ describe('GET /v1/users/1/tasks', function(){
+    var stub;
+
+    beforeEach(function () {
+      stub = sinon.stub(clientStub, 'list');
+
+      stub.withArgs(sinon.match({ id: '1' }))
+        .rejects({code: 500});
+      stub.withArgs(sinon.match({ userId: '1' }))
+        .resolves({payload: [stubs.task]});
+    });
+
     afterEach(function(){
-      clientStub.list.restore();
+      stub.restore();
     });
 
     it('return a collection', function(done){
-      sinon.stub(clientStub, 'list')
-        .withArgs(sinon.match({ userId: '1' }))
-        .resolves({payload: [stubs.task]});
-
       request(app)
         .get('/v1/users/1/tasks')
         .expect(200)
@@ -129,7 +136,6 @@ describe('Integration: Tasks Endpoints', function(){
         .end(done);
     });
   });
-
   describe('GET /v1/users/1/tasks/count', function(){
     afterEach(function(){
       clientStub.count.restore();


### PR DESCRIPTION
In the Resource Relation handler, the id payload gets used and set into a foreign key relation. The old original key however, was not removed and was kept in the payload. this ended up in unneccesary data being sent to the endpoints and the endpoints having to cope with the id even when it was not in its contract.

related with issue #107