### PR TITLE
number enforcement should check for non null or undefined values

### DIFF
--- a/lib/handlers/enforce_number.js
+++ b/lib/handlers/enforce_number.js
@@ -7,7 +7,7 @@ function enforceNumber() {
   }
   var keys = Array.prototype.slice.call(arguments, 1);
   _.each(keys, function (key) {
-    if (obj[key]) {
+    if (obj[key] !== null && obj[key] !== undefined) {
       obj[key] = parseInt(obj[key]);
       if (_.isNaN(obj[key])) {
         delete obj[key];

--- a/tests/handlers/enforce_number_test.js
+++ b/tests/handlers/enforce_number_test.js
@@ -1,0 +1,18 @@
+var target = require('../../lib/handlers/enforce_number');
+
+describe('Helper enforceNumber', function () {
+  it('should return a object', function () {
+    target({limit: 1, offset: 0}, 'limit', 'offset')
+      .should.be.eql({limit: 1, offset: 0});
+  });
+
+  it('should exclude a NaN parameter', function () {
+    target({limit: NaN}, 'limit')
+      .should.be.eql({});
+  });
+
+  it('should exclude a non numerical parameter', function () {
+    target({limit: 'abc'}, 'limit')
+      .should.be.eql({});
+  });
+});


### PR DESCRIPTION
using the previous check with where missing values such as 0 or NaN