### PR TITLE
fixed relation route generation on model with relation parent

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -81,10 +81,13 @@ function removeRoute(metadata, paths, handlers){
   };
 }
 
-function relationRoute(relation, paths, handlers){
+function relationRoute(config, relation, paths, handlers){
   var isCollection = relation.type === 'collection';
   // only define routes for subresources and not to direct resources
   if (!isCollection) { return null; }
+
+  var hasSameParent = config.metadata[relation.version][relation.model].parent == relation.parent;
+  if (hasSameParent) { return null; }
 
   log.trace(relation, 'Loading relation route');
 
@@ -106,9 +109,9 @@ function relationRoute(relation, paths, handlers){
   return routes;
 }
 
-function modelRelationsRoutes(metadata, paths, handlers){
+function modelRelationsRoutes(config, metadata, paths, handlers){
   return _.flatten(metadata.relations.map(function(relation){
-    return relationRoute(relation, paths, handlers);
+    return relationRoute(config, relation, paths, handlers);
   }));
 }
 
@@ -157,7 +160,7 @@ function relationsRoutes(config, metadata) {
   var handlers = require('./handlers')(config);
 
   return _.compact(
-    modelRelationsRoutes(metadata, paths, handlers)
+    modelRelationsRoutes(config, metadata, paths, handlers)
   );
 }
 

--- a/tests/routes_test.js
+++ b/tests/routes_test.js
@@ -1,0 +1,22 @@
+var chai = require('chai');
+    should = chai.should();
+
+describe('routes', function(){
+  var target, metadata, config;
+
+  beforeEach(function(){
+    metadata = require('./metadata/index');
+    config = {
+      runtimeConfig: { baseUrl: 'http://test', metricService: {} },
+      metadata: metadata
+    };
+    target = require('../lib/routes');
+  });
+
+  describe('#relationsRoutes', function(){
+    it('should not return relation routes from same parent', function(){
+      target.relationsRoutes(config, metadata.v1.computeInstance)
+        .should.be.eql([])
+    });
+  });
+});


### PR DESCRIPTION
when a model contains the same parent as the relation that is being
create we need to prevent the generation of the same route twice